### PR TITLE
molecule: enhance kind_cluster tests

### DIFF
--- a/molecule/delegated/tests/kind_cluster.py
+++ b/molecule/delegated/tests/kind_cluster.py
@@ -2,3 +2,28 @@ def test_kind_cluster_container(host):
     container_name = "clusterapi-control-plane"
     container = host.docker(container_name)
     assert container.is_running
+
+
+def test_kind_cluster_kubeconfig(host):
+    """Test if the kubeconfig file exists and has correct permissions."""
+    kubeconfig = host.file("/var/lib/yake/kubeconfig.clusterapi")
+    assert kubeconfig.exists
+    assert kubeconfig.mode == 0o640
+    assert not kubeconfig.is_directory
+
+
+def test_kind_cluster_running(host):
+    """Test if the KIND cluster is up and running with yake-kubectl."""
+    # Check if yake-kubectl can connect to the cluster using the kubeconfig
+    cmd = host.run(
+        "KUBECONFIG=/var/lib/yake/kubeconfig.clusterapi yake-kubectl get nodes"
+    )
+    assert cmd.rc == 0
+    assert "clusterapi-control-plane" in cmd.stdout
+
+    # Check if nodes are in Ready status
+    cmd = host.run(
+        "KUBECONFIG=/var/lib/yake/kubeconfig.clusterapi yake-kubectl get nodes -o jsonpath='{.items[*].status.conditions[?(@.type==\"Ready\")].status}'"  # noqa E501
+    )
+    assert cmd.rc == 0
+    assert "True" in cmd.stdout

--- a/roles/kind_cluster/tasks/main.yml
+++ b/roles/kind_cluster/tasks/main.yml
@@ -33,6 +33,17 @@
   async: 180
   poll: 5
 
+- name: Wait for kind cluster to be ready
+  become: "{{ kind_cluster_become }}"
+  ansible.builtin.command: >
+    /usr/local/bin/yake-kubectl --kubeconfig {{ kind_cluster_kubeconfig }} wait --for=condition=Ready nodes --all --timeout=300s
+  register: wait_result
+  until: wait_result.rc == 0
+  retries: 10
+  delay: 10
+  when: "kind_cluster_state == 'present'"
+  changed_when: false
+
 - name: Change permissions of kubeconfig
   become: true
   ansible.builtin.file:


### PR DESCRIPTION
Add comprehensive tests to verify kind cluster is fully operational:
- Check kubeconfig file exists with proper permissions
- Verify kubectl can connect to cluster and list nodes
- Confirm nodes are in Ready status

AI-assisted: Claude Code