### PR TITLE
feat(scripts): add --insecure flag to update-images.py

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,6 +49,9 @@ python3 scripts/update-images.py --skip-capi --gardenlinux-version 2150.3.0
 
 # Check what would be uploaded without actually uploading anything
 python3 scripts/update-images.py --dry-run
+
+# Skip TLS certificate verification for the OpenStack API (for self-signed certificates)
+python3 scripts/update-images.py --insecure --k8s-version 1.35.4
 ```
 
 ### What the script uploads

--- a/scripts/update-images.py
+++ b/scripts/update-images.py
@@ -40,6 +40,7 @@ except ImportError:
 
 try:
     import requests
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
 except ImportError:
     sys.exit("Missing dependency: pip install requests")
 
@@ -393,11 +394,19 @@ def main():
         action="store_true",
         help=("Check what would be uploaded without actually uploading anything"),
     )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Disable TLS certificate verification (for self-signed certs)",
+    )
     args = parser.parse_args()
+
+    if args.insecure:
+        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
     print("Connecting to OpenStack ...")
     try:
-        conn = openstack.connect(cloud=args.cloud)
+        conn = openstack.connect(cloud=args.cloud, insecure=args.insecure)
         _ = conn.auth["auth_url"]
     except Exception:
         sys.exit(


### PR DESCRIPTION
Disables TLS certificate verification for the OpenStack API connection, useful for environments with self-signed certificates.