### PR TITLE
fix(clusterapi_cluster): CA cert handling, proxy support, optional ro…

### DIFF
--- a/roles/clusterapi_cluster/defaults/main.yml
+++ b/roles/clusterapi_cluster/defaults/main.yml
@@ -4,6 +4,8 @@ clusterapi_cluster_become: false
 clusterapi_cluster_uid: "{{ ansible_facts.user_uid | string }}"
 clusterapi_cluster_gid: "{{ ansible_facts.user_gid | string }}"
 
+clusterapi_cluster_proxy_env: "{{ proxy_env | d({}) }}"
+
 clusterapi_cluster_management_cluster_name: "{{ management_cluster_name | d('clusterapi') }}"
 
 clusterapi_cluster_kubeconfig: kubeconfig
@@ -30,7 +32,6 @@ clusterapi_cluster_openstack_application_credential_id: ""
 clusterapi_cluster_openstack_application_credential_secret: ""
 clusterapi_cluster_openstack_domain_name: ""
 clusterapi_cluster_openstack_region_name: ""
-clusterapi_cluster_openstack_tls_verify: false
 clusterapi_cluster_openstack_external_network: public
 clusterapi_cluster_openstack_ssh_key_name: "{{ clusterapi_cluster_name }}"
 clusterapi_cluster_openstack_image_id: ""
@@ -45,7 +46,6 @@ clusterapi_cluster_openstack_cloud:
   interface: "public"
   identity_api_version: 3
   auth_type: "v3applicationcredential"
-  # cacert: /etc/certs/cacert.pem
 clusterapi_cluster_openstack_loadbalancer_provider: ovn
 clusterapi_cluster_openstack_managed_subnets:
   - cidr: "192.168.0.23/24"
@@ -76,8 +76,11 @@ clusterapi_cluster_worker_machine_deployments:
   #   image_id: "{{ clusterapi_cluster_openstack_image_id }}"
 clusterapi_cluster_worker_machine_flavor: "SCS-4V-8"
 
+# Set to false for flavors that include local storage (e.g. local NVMe).
+# When false, no Cinder volume is created and the flavor's ephemeral disk is used.
+clusterapi_cluster_root_volume_enabled: true
 clusterapi_cluster_root_volume_size: 20
-# Set the Openstack dafault
+# Set the OpenStack default
 clusterapi_cluster_root_volume_type: "__DEFAULT__"
 clusterapi_cluster_root_volume_availability_zone: "{{ clusterapi_cluster_openstack_failure_domain }}"
 

--- a/roles/clusterapi_cluster/tasks/create.yml
+++ b/roles/clusterapi_cluster/tasks/create.yml
@@ -162,8 +162,11 @@
         name: cloud-config
         namespace: kube-system
       type: Opaque
-      stringData:
-        cloud.conf: "{{ register_cloud_conf.content | b64decode }}"
+      stringData: >-
+        {{ {'cloud.conf': register_cloud_conf.content | b64decode} |
+           combine({'cacert.pem': clusterapi_cluster_openstack_cacert}
+                   if clusterapi_cluster_openstack_cacert | d('') | length > 0
+                   else {}) }}
 
 - name: Copy CCM manifests
   ansible.builtin.copy:

--- a/roles/clusterapi_cluster/tasks/main.yml
+++ b/roles/clusterapi_cluster/tasks/main.yml
@@ -8,6 +8,21 @@
     mode: 0755
     state: directory
 
+- name: Write OpenStack CA certificate
+  ansible.builtin.copy:
+    content: "{{ clusterapi_cluster_openstack_cacert }}"
+    dest: "/var/lib/yake/cacert-{{ clusterapi_cluster_name }}.pem"
+    owner: "{{ clusterapi_cluster_uid }}"
+    group: "{{ clusterapi_cluster_gid }}"
+    mode: 0600
+  when: clusterapi_cluster_openstack_cacert | d('') | length > 0
+
+- name: Add cacert to OpenStack cloud configuration
+  ansible.builtin.set_fact:
+    clusterapi_cluster_openstack_cloud: >-
+      {{ clusterapi_cluster_openstack_cloud | combine({'cacert': '/var/lib/yake/cacert-' ~ clusterapi_cluster_name ~ '.pem'}) }}
+  when: clusterapi_cluster_openstack_cacert | d('') | length > 0
+
 - name: Include create tasks
   ansible.builtin.include_tasks: create.yml
   when: clusterapi_cluster_state == "present"

--- a/roles/clusterapi_cluster/tasks/network-calico.yml
+++ b/roles/clusterapi_cluster/tasks/network-calico.yml
@@ -10,6 +10,7 @@
     create_namespace: true
     kubeconfig: "/var/lib/yake/kubeconfig.{{ clusterapi_cluster_name }}"
     wait: true
+  environment: "{{ clusterapi_cluster_proxy_env }}"
 
 - name: Wait for calico-node pods
   kubernetes.core.k8s_info:

--- a/roles/clusterapi_cluster/tasks/network-cilium.yml
+++ b/roles/clusterapi_cluster/tasks/network-cilium.yml
@@ -10,6 +10,7 @@
     kubeconfig: "/var/lib/yake/kubeconfig.{{ clusterapi_cluster_name }}"
     wait: true
     values: "{{ clusterapi_cluster_cilium_helm_values }}"
+  environment: "{{ clusterapi_cluster_proxy_env }}"
 
 - name: Wait for cilium pods
   kubernetes.core.k8s_info:

--- a/roles/clusterapi_cluster/templates/cloud.conf.j2
+++ b/roles/clusterapi_cluster/templates/cloud.conf.j2
@@ -5,7 +5,7 @@ application-credential-secret={{ clusterapi_cluster_openstack_application_creden
 region={{ clusterapi_cluster_openstack_region_name }}
 domain-name={{ clusterapi_cluster_openstack_domain_name }}
 {% if clusterapi_cluster_openstack_cacert | d('') %}
-ca-file=/etc/certs/cacert.pem
+ca-file=/etc/config/cacert.pem
 {% endif %}
 
 [BlockStorage]

--- a/roles/clusterapi_cluster/templates/cluster-template.yaml.j2
+++ b/roles/clusterapi_cluster/templates/cluster-template.yaml.j2
@@ -87,7 +87,6 @@ spec:
           - name: provider-id
             value: openstack:///'{% raw %}{{ instance_id }}{% endraw %}'
           name: "{% raw %}{{ local_hostname }}{% endraw %}"
-          # node-labels: "topology.kubernetes.io/zone={{ clusterapi_cluster_openstack_failure_domain }}"
           taints:
           - key: "node.cilium.io/agent-not-ready"
             value: "true"
@@ -306,11 +305,13 @@ spec:
       image:
         id: {{ clusterapi_cluster_openstack_image_id }}
       sshKeyName: {{ clusterapi_cluster_openstack_ssh_key_name }}
+{% if clusterapi_cluster_root_volume_enabled | bool %}
       rootVolume:
-        sizeGiB: {{ clusterapi_cluster_root_volume_size | d(50) }}
+        sizeGiB: {{ clusterapi_cluster_root_volume_size }}
         type: {{ clusterapi_cluster_root_volume_type }}
         availabilityZone:
           name: {{ clusterapi_cluster_root_volume_availability_zone }}
+{% endif %}
 {% for md in clusterapi_cluster_worker_machine_deployments %}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -324,9 +325,11 @@ spec:
       image:
         id: {{ md.image_id }}
       sshKeyName: {{ clusterapi_cluster_openstack_ssh_key_name }}
+{% if clusterapi_cluster_root_volume_enabled | bool %}
       rootVolume:
-        sizeGiB: {{ clusterapi_cluster_root_volume_size}}
+        sizeGiB: {{ clusterapi_cluster_root_volume_size }}
         type: {{ clusterapi_cluster_root_volume_type }}
         availabilityZone:
           name: {{ md.failure_domain }}
+{% endif %}
 {% endfor %}

--- a/scripts/update-images.py
+++ b/scripts/update-images.py
@@ -40,9 +40,14 @@ except ImportError:
 
 try:
     import requests
-    from requests.packages.urllib3.exceptions import InsecureRequestWarning
 except ImportError:
     sys.exit("Missing dependency: pip install requests")
+
+try:
+    import urllib3
+    from urllib3.exceptions import InsecureRequestWarning
+except ImportError:
+    sys.exit("Missing dependency: pip install urllib3")
 
 try:
     from tqdm import tqdm
@@ -402,7 +407,7 @@ def main():
     args = parser.parse_args()
 
     if args.insecure:
-        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+        urllib3.disable_warnings(InsecureRequestWarning)
 
     print("Connecting to OpenStack ...")
     try:


### PR DESCRIPTION
…ot volume

- Write OpenStack CA cert to disk and inject it into the cloud SDK config so Ansible OpenStack modules accept self-signed certificates
- Include cacert.pem in the cloud-config Secret so CCM/CSI pods can read it at /etc/config/cacert.pem (the path already mounted by both DaemonSets)
- Fix ca-file path in cloud.conf from /etc/certs/ to /etc/config/cacert.pem
- Add clusterapi_cluster_root_volume_enabled flag (default true) to allow flavors with local storage to skip Cinder root volume creation
- Add clusterapi_cluster_proxy_env and pass it to Cilium/Calico Helm installs so air-gapped deployments can pull charts through a proxy
- Fix urllib3 import for --insecure flag in update-images.py
- Remove unused clusterapi_cluster_openstack_tls_verify default