### PR TITLE
fix(gardener): fix terminal access and align network configuration

### DIFF
--- a/roles/clusterapi_cluster/defaults/main.yml
+++ b/roles/clusterapi_cluster/defaults/main.yml
@@ -50,7 +50,7 @@ clusterapi_cluster_openstack_cloud:
   auth_type: "v3applicationcredential"
 clusterapi_cluster_openstack_loadbalancer_provider: ovn
 clusterapi_cluster_openstack_managed_subnets:
-  - cidr: "192.168.0.23/24"
+  - cidr: "172.28.0.0/24"
     dns_nameservers:
       - "1.1.1.1"
 # Use existing subnets by ID instead of creating new ones (mutually exclusive with managedSubnets).
@@ -99,3 +99,4 @@ clusterapi_cluster_cilium_helm_values:
 
 # renovate: datasource=helm registryUrl=https://projectcalico.docs.tigera.io/charts depName=tigera-operator
 clusterapi_cluster_calico_version: "v3.32.0"
+clusterapi_cluster_calico_helm_values: {}

--- a/roles/clusterapi_cluster/tasks/network-calico.yml
+++ b/roles/clusterapi_cluster/tasks/network-calico.yml
@@ -10,6 +10,7 @@
     create_namespace: true
     kubeconfig: "/var/lib/yake/kubeconfig.{{ clusterapi_cluster_name }}"
     wait: true
+    values: "{{ clusterapi_cluster_calico_helm_values }}"
   environment: "{{ clusterapi_cluster_proxy_env }}"
 
 - name: Wait for calico-node pods

--- a/roles/gardener_operator/defaults/main.yml
+++ b/roles/gardener_operator/defaults/main.yml
@@ -7,8 +7,7 @@ gardener_operator_proxy_env: "{{ proxy_env | d({}) }}"
 
 # renovate: datasource=github-releases depName=gardener/gardener
 gardener_operator_version: '1.144.2'
-gardener_operator_helm_values:
-  replicaCount: 1
+gardener_operator_helm_values: {}
 
 # renovate: datasource=github-releases depName=dexidp/helm-charts extractVersion=^dex-(?<version>.+)$
 gardener_operator_dex_version: '0.24.1'
@@ -56,6 +55,9 @@ gardener_operator_gardenlet_image_vector_overwrite: ""
 #   - name: gardener-node-agent
 #     repository: "{{ gardener_operator_image_registry }}/gardener-project/releases/gardener/node-agent"
 #     tag: "v{{ gardener_operator_version }}"
+
+# Feature gates for all gardenlets (internal seed and managed seeds).
+gardener_operator_gardenlet_feature_gates: {}
 
 # renovate: datasource=github-releases depName=gardener/gardener-extension-provider-openstack
 gardener_operator_provider_openstack_version: '1.55.3'
@@ -192,6 +194,10 @@ gardener_operator_cloudprofiles:
         zones:
           - nova
 
+# CIDRs blocked in all shoot clusters via NetworkPolicy (e.g. cloud metadata service).
+gardener_operator_seed_block_cidrs:
+  - 169.254.169.254/32
+
 gardener_operator_managed_seeds_project_name: seeds
 
 gardener_operator_managed_seeds_registry_mirrors_ca: ""
@@ -220,8 +226,8 @@ gardener_operator_managed_seeds:
     # internal_domain: foo.example.com
     # Optional: load balancer provider (default: amphora); alternatives: haproxy, ovn
     # loadbalancer_provider: amphora
-    # Optional: use an explicit worker CIDR (default: 10.120.0.0/16)
-    # workers_cidr: "10.120.0.0/16"
+    # Optional: use an explicit worker CIDR (default: 100.96.0.0/16)
+    # workers_cidr: "100.96.0.0/16"
     # Optional: use a subnet pool instead of an explicit CIDR (mutually exclusive with workers_cidr)
     # subnet_pool:
     #   id: "subnet-pool-uuid"

--- a/roles/gardener_operator/tasks/vgarden.yml
+++ b/roles/gardener_operator/tasks/vgarden.yml
@@ -53,3 +53,22 @@
     state: present
     wait: true
     src: /var/lib/yake/gardener-operator/seed-ingress-certificate.yaml
+
+- name: Allow all egress for terminal controller manager
+  kubernetes.core.k8s:
+    kubeconfig: "/var/lib/yake/kubeconfig.{{ gardener_operator_clusterapi_name }}"
+    state: present
+    definition:
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: allow-all-egress-for-terminal-controller-manager
+        namespace: garden
+      spec:
+        podSelector:
+          matchLabels:
+            app: terminal-controller-manager
+        egress:
+          - {}
+        policyTypes:
+          - Egress

--- a/roles/gardener_operator/templates/garden.yaml.j2
+++ b/roles/gardener_operator/templates/garden.yaml.j2
@@ -167,7 +167,7 @@ spec:
                 candidateDeterminationStrategy: MinimalDistance
       gardenerDashboard:
         oidcConfig:
-          clientIDPublic: "Gardener Dashboard"
+          clientIDPublic: "kube-kubectl"
           issuerURL: https://identity.{{ gardener_operator_garden_url }}
           sessionLifetime: 12h
           additionalScopes: [ profile, offline_access ]
@@ -175,8 +175,12 @@ spec:
             name: gardener-dashboard-oidc
         terminal:
           allowedHosts:
-          - "*.internal.{{ gardener_operator_garden_url }}"
-          - "*.{{ gardener_operator_managed_seeds_project_name }}.{{ gardener_operator_garden_url }}"
+          - "api.garden.{{ gardener_operator_garden_url }}"
+          - "*.{{ gardener_operator_garden_url }}"
+          - "*.ingress.{{ gardener_operator_garden_url }}"
+{% for seed in gardener_operator_managed_seeds | d([]) %}
+          - "*.ingress.{{ seed.name }}.{{ gardener_operator_managed_seeds_project_name }}.{{ gardener_operator_garden_url }}"
+{% endfor %}
           container:
             image: {{ gardener_operator_image_registry }}/gardener-project/releases/gardener/ops-toolbelt:latest
         ingress:

--- a/roles/gardener_operator/templates/gardenlet.yaml.j2
+++ b/roles/gardener_operator/templates/gardenlet.yaml.j2
@@ -106,6 +106,10 @@ spec:
   config:
     apiVersion: gardenlet.config.gardener.cloud/v1alpha1
     kind: GardenletConfiguration
+{% if gardener_operator_gardenlet_feature_gates | d({}) %}
+    featureGates:
+{{ gardener_operator_gardenlet_feature_gates | to_nice_yaml(indent=2) | indent(6, true) }}
+{% endif %}
     gardenClientConnection:
       gardenClusterAddress: https://api.garden.{{ gardener_operator_garden_url }}
     controllers:
@@ -160,15 +164,21 @@ spec:
         ingress:
           controller:
             kind: nginx
-          domain: internal.{{ gardener_operator_garden_url }}
+          domain: ingress.{{ gardener_operator_garden_url }}
         networks:
           nodes: {{ gardener_operator_nodes_cidr }}
-          pods: 10.0.0.0/16
+          pods: 10.0.0.0/20
           services: {{ gardener_operator_services_cidr }}
           shootDefaults:
             nodes: 100.100.0.0/16
             pods: 100.101.0.0/16
             services: 100.102.0.0/16
+{% if gardener_operator_seed_block_cidrs | d([]) %}
+          blockCIDRs:
+{% for cidr in gardener_operator_seed_block_cidrs %}
+          - {{ cidr }}
+{% endfor %}
+{% endif %}
         provider:
           region: {{ gardener_operator_openstack_region_name }}
           type: openstack

--- a/roles/gardener_operator/templates/managed-seed.yaml.j2
+++ b/roles/gardener_operator/templates/managed-seed.yaml.j2
@@ -117,7 +117,7 @@ spec:
           prefixLength: {{ item.subnet_pool.prefix_length }}
 {% endif %}
 {% else %}
-        workers: {{ item.workers_cidr | d('10.120.0.0/16') }}
+        workers: {{ item.workers_cidr | d('100.96.0.0/16') }}
 {% endif %}
     controlPlaneConfig:
       apiVersion: openstack.provider.extensions.gardener.cloud/v1alpha1
@@ -143,7 +143,7 @@ spec:
         zones: {{ w.zones }}
 {% endfor %}
   networking:
-    nodes: {{ item.workers_cidr | d('10.120.0.0/16') }}
+    nodes: {{ item.workers_cidr | d('100.96.0.0/16') }}
     pods: 100.72.0.0/16
     services: 100.80.0.0/13
     type: {{ item.networking_type }}
@@ -175,6 +175,10 @@ spec:
     config:
       apiVersion: gardenlet.config.gardener.cloud/v1alpha1
       kind: GardenletConfiguration
+{% if gardener_operator_gardenlet_feature_gates | d({}) %}
+      featureGates:
+{{ gardener_operator_gardenlet_feature_gates | to_nice_yaml(indent=2) | indent(8, true) }}
+{% endif %}
       seedConfig:
         metadata:
           labels:
@@ -213,13 +217,19 @@ spec:
             controller:
               kind: nginx
           networks:
-            nodes: {{ item.workers_cidr | d('10.120.0.0/16') }}
+            nodes: {{ item.workers_cidr | d('100.96.0.0/16') }}
             pods: 100.72.0.0/16
             services: 100.80.0.0/13
             shootDefaults:
-              nodes: 10.121.0.0/16
+              nodes: 100.97.0.0/16
               pods: 100.73.0.0/16
               services: 100.88.0.0/13
+{% if gardener_operator_seed_block_cidrs | d([]) %}
+            blockCIDRs:
+{% for cidr in gardener_operator_seed_block_cidrs %}
+            - {{ cidr }}
+{% endfor %}
+{% endif %}
           provider:
             type: openstack
             region: {{ item.openstack.region_name }}

--- a/roles/gardener_operator/templates/seed-ingress-certificate.yaml.j2
+++ b/roles/gardener_operator/templates/seed-ingress-certificate.yaml.j2
@@ -10,7 +10,9 @@ metadata:
   name: seed-ingress
   namespace: garden
 spec:
-  commonName: "*.internal.{{ gardener_operator_garden_url }}"
+  commonName: "*.ingress.{{ gardener_operator_garden_url }}"
+  dnsNames:
+  - "*.{{ gardener_operator_garden_url }}"
   issuerRef:
     name: garden
     namespace: garden

--- a/roles/gardener_operator/vars/main.yml
+++ b/roles/gardener_operator/vars/main.yml
@@ -1,2 +1,3 @@
 ---
-_gardener_operator_helm_values: {}  # noqa: var-naming[no-role-prefix]
+_gardener_operator_helm_values:  # noqa: var-naming[no-role-prefix]
+  replicaCount: 2


### PR DESCRIPTION
Fix Gardener Dashboard terminal by correcting clientIDPublic from "Gardener Dashboard" to "kube-kubectl" (Dex client ID, not name), updating terminal allowedHosts to use ingress subdomain patterns, and adding a NetworkPolicy to allow egress for the terminal-controller-manager.

Rename internal seed ingress domain from internal.* to ingress.* and extend the seed ingress certificate with a wildcard dnsName.

Move operator replicaCount: 2 to internal _gardener_operator_helm_values so it is no longer an exposed user option. Add gardenlet featureGates and seed blockCIDRs (169.254.169.254/32) support for internal seed and managed seeds.

Align managed seed network CIDRs to RFC 6598 (100.96.0.0/16, 100.97.0.0/16) for consistency with other Gardener-managed networks, and reduce internal seed pod CIDR from /16 to /20. Update default clusterapi_cluster subnet to 172.28.0.0/24 and add clusterapi_cluster_calico_helm_values variable.