### PR TITLE
feat: add proxy env and auto-restart to CLI tool containers

### DIFF
--- a/roles/clusterctl_install/tasks/main.yml
+++ b/roles/clusterctl_install/tasks/main.yml
@@ -17,12 +17,11 @@
     name: clusterctl
     command: sleep infinity
     image: "{{ clusterctl_install_container_registry }}/{{ clusterctl_install_container_image }}:{{ clusterctl_install_version }}"
-    env:
-      USER_ID: "{{ clusterctl_install_uid }}"
-      GROUP_ID: "{{ clusterctl_install_gid }}"
+    env: "{{ {'USER_ID': clusterctl_install_uid, 'GROUP_ID': clusterctl_install_gid} | combine(clusterctl_install_proxy_env) }}"
     volumes:
       - /var/lib/yake://var/lib/yake
     network_mode: host
+    restart_policy: unless-stopped
     state: started
   when: clusterctl_install_method == "docker"
 

--- a/roles/helm_install/tasks/main.yml
+++ b/roles/helm_install/tasks/main.yml
@@ -17,12 +17,11 @@
     name: helm
     command: sleep infinity
     image: "{{ helm_install_container_registry }}/{{ helm_install_container_image }}:{{ helm_install_version }}"
-    env:
-      USER_ID: "{{ helm_install_uid }}"
-      GROUP_ID: "{{ helm_install_gid }}"
+    env: "{{ {'USER_ID': helm_install_uid, 'GROUP_ID': helm_install_gid} | combine(helm_install_proxy_env) }}"
     volumes:
       - /var/lib/yake:/var/lib/yake
       - /tmp:/tmp
+    restart_policy: unless-stopped
     state: started
   when: helm_install_method == "docker"
 

--- a/roles/kubectl_install/tasks/main.yml
+++ b/roles/kubectl_install/tasks/main.yml
@@ -17,12 +17,11 @@
     name: kubectl
     command: sleep infinity
     image: "{{ kubectl_install_container_registry }}/{{ kubectl_install_container_image }}:{{ kubectl_install_version }}"
-    env:
-      USER_ID: "{{ kubectl_install_uid }}"
-      GROUP_ID: "{{ kubectl_install_gid }}"
+    env: "{{ {'USER_ID': kubectl_install_uid, 'GROUP_ID': kubectl_install_gid} | combine(kubectl_install_proxy_env) }}"
     volumes:
       - /var/lib/yake:/var/lib/yake
     network_mode: host
+    restart_policy: unless-stopped
     state: started
   when: kubectl_install_method == "docker"
 

--- a/roles/management_cluster/tasks/kind.yml
+++ b/roles/management_cluster/tasks/kind.yml
@@ -61,7 +61,6 @@
     --image {{ management_cluster_kind_cluster_image }}
     --kubeconfig {{ management_cluster_kubeconfig }}
     --config /var/lib/yake/config.{{ management_cluster_name }}.yml
-  environment: "{{ management_cluster_proxy_env }}"
   when:
     - management_cluster_kind_state == 'present'
     - management_cluster_name not in kind_clusters.stdout_lines

--- a/roles/management_cluster/tasks/kind.yml
+++ b/roles/management_cluster/tasks/kind.yml
@@ -5,13 +5,12 @@
     name: kind
     command: sleep infinity
     image: "{{ management_cluster_kind_registry }}/{{ management_cluster_kind_image }}:{{ management_cluster_kind_version }}"
-    env:
-      USER_ID: "{{ management_cluster_uid }}"
-      GROUP_ID: "{{ management_cluster_gid }}"
+    env: "{{ {'USER_ID': management_cluster_uid, 'GROUP_ID': management_cluster_gid} | combine(management_cluster_proxy_env) }}"
     volumes:
       - /var/lib/yake:/var/lib/yake
       - /var/run/docker.sock:/var/run/docker.sock
     network_mode: host
+    restart_policy: unless-stopped
     state: started
   when: management_cluster_kind_method == "docker"
 
@@ -62,6 +61,7 @@
     --image {{ management_cluster_kind_cluster_image }}
     --kubeconfig {{ management_cluster_kubeconfig }}
     --config /var/lib/yake/config.{{ management_cluster_name }}.yml
+  environment: "{{ management_cluster_proxy_env }}"
   when:
     - management_cluster_kind_state == 'present'
     - management_cluster_name not in kind_clusters.stdout_lines


### PR DESCRIPTION
Pass proxy_env into all tool containers (kubectl, helm, clusterctl, kind) via the env parameter. Add restart_policy: unless-stopped so containers come back up automatically after a VM reboot.

Also pass proxy_env when running kind create cluster so kind injects it into the containerd configuration of the kind nodes.