### PR TITLE
feat: add custom hosts entries support for OpenStack endpoints

### DIFF
--- a/roles/clusterapi_cluster/defaults/main.yml
+++ b/roles/clusterapi_cluster/defaults/main.yml
@@ -86,7 +86,8 @@ clusterapi_cluster_root_volume_size: 20
 clusterapi_cluster_root_volume_type: "__DEFAULT__"
 clusterapi_cluster_root_volume_availability_zone: "{{ clusterapi_cluster_openstack_failure_domain }}"
 
-clusterapi_cluster_csi_snapshotter_enable: false
+# Requires VolumeSnapshot CRDs and a SnapshotClass to be installed separately.
+clusterapi_cluster_csi_snapshotter_enabled: false
 
 clusterapi_cluster_extra: {}
 

--- a/roles/clusterapi_cluster/tasks/create.yml
+++ b/roles/clusterapi_cluster/tasks/create.yml
@@ -208,6 +208,7 @@
     executable: /bin/bash
   loop: "{{ clusterapi_cluster_hosts_entries }}"
   when: clusterapi_cluster_hosts_entries | d([]) | length > 0
+  changed_when: false
 
 - name: Apply CCM manifests
   kubernetes.core.k8s:
@@ -264,13 +265,16 @@
     executable: /bin/bash
   loop: "{{ ['cinder-csi-controllerplugin.yaml', 'cinder-csi-nodeplugin.yaml'] | product(clusterapi_cluster_hosts_entries) | list }}"
   when: clusterapi_cluster_hosts_entries | d([]) | length > 0
+  changed_when: false
 
 - name: Remove csi-snapshotter if disabled
   ansible.builtin.shell:
     cmd: |
+      set -o pipefail
       yq -yi '.spec.template.spec.containers |= map(select(.name != "csi-snapshotter"))' /var/lib/yake/cinder-csi-controllerplugin.yaml
     executable: /bin/bash
   when: not clusterapi_cluster_csi_snapshotter_enabled | bool
+  changed_when: false
 
 - name: Apply CSI manifests
   kubernetes.core.k8s:

--- a/roles/clusterapi_cluster/tasks/create.yml
+++ b/roles/clusterapi_cluster/tasks/create.yml
@@ -201,6 +201,14 @@
     - cloud-controller-manager-roles.yaml
     - openstack-cloud-controller-manager-ds.yaml
 
+- name: Add hosts entries to CCM DaemonSet manifest
+  ansible.builtin.shell:
+    cmd: |
+      yq -yi '.spec.template.spec.hostAliases += [{"ip": "{{ item.ip }}", "hostnames": ["{{ item.hostname }}"]}]' /var/lib/yake/openstack-cloud-controller-manager-ds.yaml
+    executable: /bin/bash
+  loop: "{{ clusterapi_cluster_hosts_entries }}"
+  when: clusterapi_cluster_hosts_entries | d([]) | length > 0
+
 - name: Apply CCM manifests
   kubernetes.core.k8s:
     kubeconfig: "/var/lib/yake/kubeconfig.{{ clusterapi_cluster_name }}"
@@ -249,15 +257,20 @@
     - cinder-csi-nodeplugin.yaml
     - csi-cinder-driver.yaml
 
+- name: Add hosts entries to CSI plugin manifests
+  ansible.builtin.shell:
+    cmd: |
+      yq -yi '.spec.template.spec.hostAliases += [{"ip": "{{ item.1.ip }}", "hostnames": ["{{ item.1.hostname }}"]}]' /var/lib/yake/{{ item.0 }}
+    executable: /bin/bash
+  loop: "{{ ['cinder-csi-controllerplugin.yaml', 'cinder-csi-nodeplugin.yaml'] | product(clusterapi_cluster_hosts_entries) | list }}"
+  when: clusterapi_cluster_hosts_entries | d([]) | length > 0
+
 - name: Remove csi-snapshotter if disabled
   ansible.builtin.shell:
     cmd: |
-      set -o pipefail
       yq -yi '.spec.template.spec.containers |= map(select(.name != "csi-snapshotter"))' /var/lib/yake/cinder-csi-controllerplugin.yaml
     executable: /bin/bash
-  register: disabled_csi_snapshotter  # noqa: var-naming[no-role-prefix]
-  changed_when: disabled_csi_snapshotter.rc != 0  # noqa: var-naming[no-role-prefix]
-  when: not clusterapi_cluster_csi_snapshotter_enable | bool
+  when: not clusterapi_cluster_csi_snapshotter_enabled | bool
 
 - name: Apply CSI manifests
   kubernetes.core.k8s:

--- a/roles/clusterapi_cluster/templates/cluster-template.yaml.j2
+++ b/roles/clusterapi_cluster/templates/cluster-template.yaml.j2
@@ -73,11 +73,25 @@ spec:
           content: |
 {{ clusterapi_cluster_openstack_cacert | indent(12, true) }}
 {% endif %}
-{% if clusterapi_cluster_hosts_entries | d([]) | length > 0 %}
+{% if clusterapi_cluster_proxy_env | d({}) | length > 0 %}
+        - path: /etc/systemd/system/containerd.service.d/http-proxy.conf
+          owner: root:root
+          permissions: "0644"
+          content: |
+            [Service]
+{% for key, value in clusterapi_cluster_proxy_env.items() %}
+            Environment="{{ key | upper }}={{ value }}"
+{% endfor %}
+{% endif %}
+{% if clusterapi_cluster_hosts_entries | d([]) | length > 0 or clusterapi_cluster_proxy_env | d({}) | length > 0 %}
       preKubeadmCommands:
-{% for entry in clusterapi_cluster_hosts_entries %}
+{% for entry in clusterapi_cluster_hosts_entries | d([]) %}
         - echo "{{ entry.ip }} {{ entry.hostname }}" >> /etc/hosts
 {% endfor %}
+{% if clusterapi_cluster_proxy_env | d({}) | length > 0 %}
+        - systemctl daemon-reload
+        - systemctl restart containerd
+{% endif %}
 {% endif %}
       joinConfiguration:
         nodeRegistration:
@@ -211,11 +225,25 @@ spec:
         content: |
 {{ clusterapi_cluster_openstack_cacert | indent(10, true) }}
 {% endif %}
-{% if clusterapi_cluster_hosts_entries | d([]) | length > 0 %}
+{% if clusterapi_cluster_proxy_env | d({}) | length > 0 %}
+      - path: /etc/systemd/system/containerd.service.d/http-proxy.conf
+        owner: root:root
+        permissions: "0644"
+        content: |
+          [Service]
+{% for key, value in clusterapi_cluster_proxy_env.items() %}
+          Environment="{{ key | upper }}={{ value }}"
+{% endfor %}
+{% endif %}
+{% if clusterapi_cluster_hosts_entries | d([]) | length > 0 or clusterapi_cluster_proxy_env | d({}) | length > 0 %}
     preKubeadmCommands:
-{% for entry in clusterapi_cluster_hosts_entries %}
+{% for entry in clusterapi_cluster_hosts_entries | d([]) %}
       - echo "{{ entry.ip }} {{ entry.hostname }}" >> /etc/hosts
 {% endfor %}
+{% if clusterapi_cluster_proxy_env | d({}) | length > 0 %}
+      - systemctl daemon-reload
+      - systemctl restart containerd
+{% endif %}
 {% endif %}
     clusterConfiguration:
       controllerManager:

--- a/roles/clusterapi_install/defaults/main.yml
+++ b/roles/clusterapi_install/defaults/main.yml
@@ -6,3 +6,8 @@ clusterapi_install_cluster_topology: true
 clusterapi_install_uid: "{{ ansible_facts.user_uid | string }}"
 clusterapi_install_gid: "{{ ansible_facts.user_gid | string }}"
 clusterapi_install_proxy_env: "{{ proxy_env | d({}) }}"
+
+clusterapi_install_hosts_entries: []
+# clusterapi_install_hosts_entries:
+#   - ip: "12.34.56.54"
+#     hostname: "keystone.services.example.com"

--- a/roles/clusterapi_install/tasks/main.yml
+++ b/roles/clusterapi_install/tasks/main.yml
@@ -36,6 +36,31 @@
     state: present
     src: /var/lib/yake/install-orc.yaml
 
+- name: Build host aliases for CAPO and ORC controllers
+  ansible.builtin.set_fact:
+    _clusterapi_install_host_aliases: "{{ _clusterapi_install_host_aliases | d([]) + [{'ip': item.ip, 'hostnames': [item.hostname]}] }}"
+  loop: "{{ clusterapi_install_hosts_entries }}"
+  when: clusterapi_install_hosts_entries | d([]) | length > 0
+
+- name: Add hosts entries to CAPO and ORC controllers
+  kubernetes.core.k8s:
+    kubeconfig: "/var/lib/yake/kubeconfig.{{ clusterapi_install_clusterapi_name }}"
+    state: patched
+    kind: Deployment
+    namespace: "{{ item.namespace }}"
+    name: "{{ item.name }}"
+    definition:
+      spec:
+        template:
+          spec:
+            hostAliases: "{{ _clusterapi_install_host_aliases }}"
+  loop:
+    - namespace: capo-system
+      name: capo-controller-manager
+    - namespace: orc-system
+      name: orc-controller-manager
+  when: clusterapi_install_hosts_entries | d([]) | length > 0
+
 - name: Wait for all pods to be ready
   become: "{{ clusterapi_install_become }}"
   ansible.builtin.shell:


### PR DESCRIPTION
Allows injecting /etc/hosts entries into all components that reach OpenStack APIs, needed when endpoints are not yet in DNS.

- clusterapi_cluster: hostAliases via yq for CCM and CSI plugin pods
- clusterapi_install: hostAliases patch for CAPO and ORC controllers
- clusterapi_cluster_csi_snapshotter_enable renamed to _enabled, default stays false (requires VolumeSnapshot CRDs and SnapshotClass)