### PR TITLE
feat: inject proxy env into Gardener extension pods via Kyverno

### DIFF
--- a/roles/clusterapi_cluster/defaults/main.yml
+++ b/roles/clusterapi_cluster/defaults/main.yml
@@ -49,7 +49,8 @@ clusterapi_cluster_openstack_cloud:
   identity_api_version: 3
   auth_type: "v3applicationcredential"
 clusterapi_cluster_openstack_loadbalancer_provider: ovn
-clusterapi_cluster_pod_cidr: "10.244.0.0/16"
+clusterapi_cluster_pod_cidr_blocks:
+  - "10.244.0.0/16"
 
 clusterapi_cluster_openstack_managed_subnets:
   - cidr: "172.28.0.0/24"
@@ -101,8 +102,7 @@ clusterapi_cluster_cilium_helm_values:
   policyCIDRMatchMode: nodes
   ipam:
     operator:
-      clusterPoolIPv4PodCIDRList:
-        - "{{ clusterapi_cluster_pod_cidr }}"
+      clusterPoolIPv4PodCIDRList: "{{ clusterapi_cluster_pod_cidr_blocks }}"
 
 # renovate: datasource=helm registryUrl=https://projectcalico.docs.tigera.io/charts depName=tigera-operator
 clusterapi_cluster_calico_version: "v3.32.0"

--- a/roles/clusterapi_cluster/defaults/main.yml
+++ b/roles/clusterapi_cluster/defaults/main.yml
@@ -49,6 +49,8 @@ clusterapi_cluster_openstack_cloud:
   identity_api_version: 3
   auth_type: "v3applicationcredential"
 clusterapi_cluster_openstack_loadbalancer_provider: ovn
+clusterapi_cluster_pod_cidr: "10.244.0.0/16"
+
 clusterapi_cluster_openstack_managed_subnets:
   - cidr: "172.28.0.0/24"
     dns_nameservers:
@@ -97,6 +99,10 @@ clusterapi_cluster_network: cilium
 clusterapi_cluster_cilium_version: "1.19.3"
 clusterapi_cluster_cilium_helm_values:
   policyCIDRMatchMode: nodes
+  ipam:
+    operator:
+      clusterPoolIPv4PodCIDRList:
+        - "{{ clusterapi_cluster_pod_cidr }}"
 
 # renovate: datasource=helm registryUrl=https://projectcalico.docs.tigera.io/charts depName=tigera-operator
 clusterapi_cluster_calico_version: "v3.32.0"

--- a/roles/clusterapi_cluster/templates/cluster-template.yaml.j2
+++ b/roles/clusterapi_cluster/templates/cluster-template.yaml.j2
@@ -114,7 +114,7 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 10.244.0.0/16
+        - {{ clusterapi_cluster_pod_cidr }}
     serviceDomain: cluster.local
   controlPlaneRef:
     apiGroup: controlplane.cluster.x-k8s.io

--- a/roles/clusterapi_cluster/templates/cluster-template.yaml.j2
+++ b/roles/clusterapi_cluster/templates/cluster-template.yaml.j2
@@ -113,8 +113,7 @@ metadata:
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks:
-        - {{ clusterapi_cluster_pod_cidr }}
+      cidrBlocks: {{ clusterapi_cluster_pod_cidr_blocks | to_json }}
     serviceDomain: cluster.local
   controlPlaneRef:
     apiGroup: controlplane.cluster.x-k8s.io

--- a/roles/gardener_operator/defaults/main.yml
+++ b/roles/gardener_operator/defaults/main.yml
@@ -7,6 +7,8 @@ gardener_operator_proxy_env: "{{ proxy_env | d({}) }}"
 
 # renovate: datasource=github-releases depName=gardener/gardener
 gardener_operator_version: '1.145.0'
+# renovate: datasource=helm registryUrl=https://kyverno.github.io/kyverno/ depName=kyverno
+gardener_operator_kyverno_version: '3.8.1'
 gardener_operator_helm_values: {}
 
 # renovate: datasource=github-releases depName=dexidp/helm-charts extractVersion=^dex-(?<version>.+)$

--- a/roles/gardener_operator/defaults/main.yml
+++ b/roles/gardener_operator/defaults/main.yml
@@ -4,6 +4,8 @@ gardener_operator_gid: "{{ ansible_facts.user_gid | string }}"
 
 gardener_operator_clusterapi_name: garden
 gardener_operator_proxy_env: "{{ proxy_env | d({}) }}"
+gardener_operator_proxy_host: ""
+gardener_operator_proxy_port: 3128
 
 # renovate: datasource=github-releases depName=gardener/gardener
 gardener_operator_version: '1.145.0'

--- a/roles/gardener_operator/tasks/main.yml
+++ b/roles/gardener_operator/tasks/main.yml
@@ -170,6 +170,33 @@
     minutes: 4
   changed_when: false
 
+- name: Wait for DNS extension namespace
+  kubernetes.core.k8s_info:
+    kubeconfig: "/var/lib/yake/kubeconfig.{{ gardener_operator_clusterapi_name }}"
+    kind: Namespace
+    name: "{{ _gardener_operator_dns_provider_namespace_map[gardener_operator_dns_provider_type] }}"
+  register: dns_extension_ns  # noqa: var-naming[no-role-prefix]
+  until: dns_extension_ns.resources | length > 0
+  retries: 30
+  delay: 20
+  when: gardener_operator_proxy_host | d('') | length > 0
+
+- name: Template proxy NetworkPolicy for DNS extension namespace
+  ansible.builtin.template:
+    src: proxy-network-policy.yaml.j2
+    dest: /var/lib/yake/gardener-operator/proxy-network-policy.yaml
+    owner: "{{ gardener_operator_uid }}"
+    group: "{{ gardener_operator_gid }}"
+    mode: 0644
+  when: gardener_operator_proxy_host | d('') | length > 0
+
+- name: Apply proxy NetworkPolicy to DNS extension namespace
+  kubernetes.core.k8s:
+    kubeconfig: "/var/lib/yake/kubeconfig.{{ gardener_operator_clusterapi_name }}"
+    state: present
+    src: /var/lib/yake/gardener-operator/proxy-network-policy.yaml
+  when: gardener_operator_proxy_host | d('') | length > 0
+
 - name: Include dex tasks
   ansible.builtin.include_tasks: dex.yml
 

--- a/roles/gardener_operator/tasks/main.yml
+++ b/roles/gardener_operator/tasks/main.yml
@@ -86,6 +86,41 @@
         gardener_operator_services_cidr == '' or
         gardener_operator_pods_cidr == ''
 
+- name: Install Kyverno
+  kubernetes.core.helm:
+    binary_path: "{{ playbook_dir }}/.local/yake-helm"
+    kubeconfig: "/var/lib/yake/kubeconfig.{{ gardener_operator_clusterapi_name }}"
+    chart_ref: kyverno
+    chart_repo_url: https://kyverno.github.io/kyverno/
+    chart_version: "{{ gardener_operator_kyverno_version }}"
+    create_namespace: true
+    release_name: kyverno
+    release_namespace: kyverno
+    release_state: present
+    wait: true
+    values:
+      features:
+        forceFailurePolicyIgnore:
+          enabled: true
+  environment: "{{ gardener_operator_proxy_env }}"
+  when: gardener_operator_proxy_env | d({}) | length > 0
+
+- name: Template Kyverno proxy injection policy
+  ansible.builtin.template:
+    src: kyverno-proxy-policy.yaml.j2
+    dest: /var/lib/yake/gardener-operator/kyverno-proxy-policy.yaml
+    owner: "{{ gardener_operator_uid }}"
+    group: "{{ gardener_operator_gid }}"
+    mode: 0644
+  when: gardener_operator_proxy_env | d({}) | length > 0
+
+- name: Apply Kyverno proxy injection policy
+  kubernetes.core.k8s:
+    kubeconfig: "/var/lib/yake/kubeconfig.{{ gardener_operator_clusterapi_name }}"
+    state: present
+    src: /var/lib/yake/gardener-operator/kyverno-proxy-policy.yaml
+  when: gardener_operator_proxy_env | d({}) | length > 0
+
 - name: Template garden files and dependencies
   ansible.builtin.template:
     src: "{{ item }}.j2"

--- a/roles/gardener_operator/tasks/main.yml
+++ b/roles/gardener_operator/tasks/main.yml
@@ -28,7 +28,11 @@
     release_namespace: garden
     release_state: present
     wait: true
-    values: "{{ _gardener_operator_helm_values | combine(gardener_operator_helm_values, recursive=True) }}"
+    values: >-
+      {{ _gardener_operator_helm_values
+         | combine({'env': gardener_operator_proxy_env | dict2items(key_name='name', value_name='value')}
+                   if gardener_operator_proxy_env | d({}) | length > 0 else {}, recursive=True)
+         | combine(gardener_operator_helm_values, recursive=True) }}
   environment: "{{ gardener_operator_proxy_env }}"
 
 - name: Extract node CIDR from first InternalIP

--- a/roles/gardener_operator/templates/extensions.yaml.j2
+++ b/roles/gardener_operator/templates/extensions.yaml.j2
@@ -144,6 +144,15 @@ spec:
       helm:
         ociRepository:
           ref: {{ gardener_operator_image_registry }}/gardener-project/releases/charts/gardener/extensions/shoot-dns-service:v{{ gardener_operator_shoot_dns_service_version }}
+{% if gardener_operator_proxy_env | d({}) | length > 0 %}
+      runtimeClusterValues:
+        dnsControllerManager:
+          env:
+{% for key, value in gardener_operator_proxy_env.items() %}
+          - name: {{ key | upper }}
+            value: "{{ value }}"
+{% endfor %}
+{% endif %}
   resources:
   - autoEnable:
     - shoot

--- a/roles/gardener_operator/templates/gardenlet.yaml.j2
+++ b/roles/gardener_operator/templates/gardenlet.yaml.j2
@@ -96,6 +96,13 @@ spec:
   deployment:
     replicaCount: 1
     revisionHistoryLimit: 2
+{% if gardener_operator_proxy_env | d({}) | length > 0 %}
+    env:
+{% for key, value in gardener_operator_proxy_env.items() %}
+    - name: {{ key | upper }}
+      value: "{{ value }}"
+{% endfor %}
+{% endif %}
     helm:
       ociRepository:
         ref: {{ gardener_operator_image_registry }}/gardener-project/releases/charts/gardener/gardenlet:v{{ gardener_operator_version }}

--- a/roles/gardener_operator/templates/gardenlet.yaml.j2
+++ b/roles/gardener_operator/templates/gardenlet.yaml.j2
@@ -174,7 +174,7 @@ spec:
           domain: ingress.{{ gardener_operator_garden_url }}
         networks:
           nodes: {{ gardener_operator_nodes_cidr }}
-          pods: 10.0.0.0/20
+          pods: {{ gardener_operator_pods_cidr }}
           services: {{ gardener_operator_services_cidr }}
           shootDefaults:
             nodes: 100.100.0.0/16

--- a/roles/gardener_operator/templates/kyverno-proxy-policy.yaml.j2
+++ b/roles/gardener_operator/templates/kyverno-proxy-policy.yaml.j2
@@ -1,6 +1,6 @@
 {%- set _ns = namespace(items=[]) -%}
 {%- for key, value in gardener_operator_proxy_env.items() -%}
-{%- set _ns.items = _ns.items + ['{"name":"' + (key | upper) + '","value":"' + value + '"}'] -%}
+{%- set _ns.items = _ns.items + ['Object.spec.containers.env{name:"' + key + '",value:"' + value + '"}'] -%}
 {%- endfor -%}
 {%- set _cel_env = '[' + (_ns.items | join(', ')) + ']' -%}
 ---
@@ -26,7 +26,7 @@ spec:
           spec: Object.spec{
             containers: object.spec.containers.map(c, Object.spec.containers{
               name: c.name,
-              env: (has(c.env) ? c.env : []) + {{ _cel_env }}
+              env: {{ _cel_env }}
             })
           }
         }
@@ -38,7 +38,7 @@ spec:
           spec: Object.spec{
             initContainers: object.spec.initContainers.map(ic, Object.spec.initContainers{
               name: ic.name,
-              env: (has(ic.env) ? ic.env : []) + {{ _cel_env }}
+              env: {{ _cel_env }}
             })
           }
         } : Object{}

--- a/roles/gardener_operator/templates/kyverno-proxy-policy.yaml.j2
+++ b/roles/gardener_operator/templates/kyverno-proxy-policy.yaml.j2
@@ -1,0 +1,44 @@
+{%- set _ns = namespace(items=[]) -%}
+{%- for key, value in gardener_operator_proxy_env.items() -%}
+{%- set _ns.items = _ns.items + ['{"name":"' + (key | upper) + '","value":"' + value + '"}'] -%}
+{%- endfor -%}
+{%- set _cel_env = '[' + (_ns.items | join(', ')) + ']' -%}
+---
+apiVersion: policies.kyverno.io/v1
+kind: MutatingPolicy
+metadata:
+  name: inject-proxy-env
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+      operations: ["CREATE"]
+    namespaceSelector:
+      matchLabels:
+        gardener.cloud/role: extension
+  mutations:
+  - patchType: ApplyConfiguration
+    applyConfiguration:
+      expression: |
+        Object{
+          spec: Object.spec{
+            containers: object.spec.containers.map(c, Object.spec.containers{
+              name: c.name,
+              env: (has(c.env) ? c.env : []) + {{ _cel_env }}
+            })
+          }
+        }
+  - patchType: ApplyConfiguration
+    applyConfiguration:
+      expression: |
+        has(object.spec.initContainers) ?
+        Object{
+          spec: Object.spec{
+            initContainers: object.spec.initContainers.map(ic, Object.spec.initContainers{
+              name: ic.name,
+              env: (has(ic.env) ? ic.env : []) + {{ _cel_env }}
+            })
+          }
+        } : Object{}

--- a/roles/gardener_operator/templates/proxy-network-policy.yaml.j2
+++ b/roles/gardener_operator/templates/proxy-network-policy.yaml.j2
@@ -1,0 +1,17 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-proxy-egress
+  namespace: {{ _gardener_operator_dns_provider_namespace_map[gardener_operator_dns_provider_type] }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: "{{ gardener_operator_proxy_host }}/32"
+    ports:
+    - protocol: TCP
+      port: {{ gardener_operator_proxy_port }}

--- a/roles/gardener_operator/vars/main.yml
+++ b/roles/gardener_operator/vars/main.yml
@@ -1,3 +1,9 @@
 ---
 _gardener_operator_helm_values:  # noqa: var-naming[no-role-prefix]
   replicaCount: 2
+
+_gardener_operator_dns_provider_namespace_map:  # noqa: var-naming[no-role-prefix]
+  azure-dns: runtime-extension-provider-azure
+  aws-route53: runtime-extension-provider-aws
+  google-clouddns: runtime-extension-provider-gcp
+  openstack-designate: runtime-extension-provider-openstack


### PR DESCRIPTION
Installs Kyverno (chart 3.8.1 / app v1.18.1) conditionally when gardener_operator_proxy_env is set. A MutatingPolicy (policies.kyverno.io/v1) patches all containers and initContainers in namespaces labelled gardener.cloud/role=extension — the label Gardener Operator sets on every extension runtime namespace — with the configured proxy env vars.

Kyverno is installed with forceFailurePolicyIgnore=true so a Kyverno restart cannot block pod creation in extension namespaces.

Additionally injects proxy env natively into shoot-dns-service via runtimeClusterValues.dnsControllerManager.env, which the chart supports directly and avoids double-injection from Kyverno for that extension.