### PR TITLE
Allow raw Helm values for provider-openstack extension

### DIFF
--- a/roles/gardener_operator/README.md
+++ b/roles/gardener_operator/README.md
@@ -44,6 +44,17 @@ This role deploys the Gardener Operator on an existing Kubernetes cluster and co
 | `gardener_operator_openstack_cacert` | PEM-encoded CA certificate (optional). |
 | `gardener_operator_openstack_zones` | List of availability zones. |
 
+`gardener_operator_provider_openstack_helm_values` is merged as-is into the `provider-openstack` extension's Helm chart values (empty by default, no override). Use it for anything the chart supports but this role doesn't expose directly, e.g. the etcd storage class provisioned for shoot control planes ([`config.etcd.storage`](https://github.com/gardener/gardener-extension-provider-openstack/blob/master/charts/gardener-extension-provider-openstack/values.yaml)):
+
+```yaml
+gardener_operator_provider_openstack_helm_values:
+  config:
+    etcd:
+      storage:
+        className: my-fast-storage-class
+        capacity: 25Gi
+```
+
 ### DNS Provider
 
 `gardener_operator_dns_provider_type` selects the DNS provider. Supported values: `openstack-designate`, `aws-route53`, `azure-dns`, `google-clouddns`.

--- a/roles/gardener_operator/defaults/main.yml
+++ b/roles/gardener_operator/defaults/main.yml
@@ -81,6 +81,10 @@ gardener_operator_provider_openstack_version: '1.57.0'
 gardener_operator_provider_openstack_storageclass_name: default
 # gardener_operator_provider_openstack_storageclass_type: default
 gardener_operator_provider_openstack_storageclass_zone: nova
+# Raw values merged into the provider-openstack extension's Helm chart, e.g. to override
+# the etcd storage class it provisions for shoot control planes (config.etcd.storage).
+# https://github.com/gardener/gardener-extension-provider-openstack/blob/master/charts/gardener-extension-provider-openstack/values.yaml
+gardener_operator_provider_openstack_helm_values: {}
 
 # DNS Provider (independent of infrastructure provider)
 # Supported types: openstack-designate, aws-route53, azure-dns, google-clouddns

--- a/roles/gardener_operator/templates/extensions.yaml.j2
+++ b/roles/gardener_operator/templates/extensions.yaml.j2
@@ -20,6 +20,10 @@ spec:
       helm:
         ociRepository:
           ref: {{ gardener_operator_image_registry }}/gardener-project/public/charts/gardener/extensions/provider-openstack:v{{ gardener_operator_provider_openstack_version }}
+{% if gardener_operator_provider_openstack_helm_values | d({}) %}
+        values:
+{{ gardener_operator_provider_openstack_helm_values | to_nice_yaml(indent=2) | indent(10, true) }}
+{% endif %}
       injectGardenKubeconfig: true
   resources:
     - kind: BackupBucket

--- a/roles/gardener_operator/templates/extensions.yaml.j2
+++ b/roles/gardener_operator/templates/extensions.yaml.j2
@@ -21,8 +21,8 @@ spec:
         ociRepository:
           ref: {{ gardener_operator_image_registry }}/gardener-project/public/charts/gardener/extensions/provider-openstack:v{{ gardener_operator_provider_openstack_version }}
 {% if gardener_operator_provider_openstack_helm_values | d({}) %}
-        values:
-{{ gardener_operator_provider_openstack_helm_values | to_nice_yaml(indent=2) | indent(10, true) }}
+      values:
+{{ gardener_operator_provider_openstack_helm_values | to_nice_yaml(indent=2) | indent(8, true) }}
 {% endif %}
       injectGardenKubeconfig: true
   resources:


### PR DESCRIPTION
The provider-openstack extension hardcodes an etcd storage class named "gardener.cloud-fast" for shoot control-plane etcd volumes (config.etcd.storage in its own chart), but this role only creates a StorageClass named after gardener_operator_provider_openstack_ storageclass_name (default "default") for shoot workloads. Without a matching "gardener.cloud-fast" class in the seed, shoot etcd PVCs stay pending.

Rather than hardcoding a fix for this one setting, add a generic gardener_operator_provider_openstack_helm_values variable that is merged as-is into the provider-openstack Extension's Helm chart values (deployment.extension.helm.values), defaulting to {} so behavior is unchanged until configured. This lets operators override the etcd storage class, or any other chart value, without needing a dedicated role variable per setting.

DocImpact
Assisted-by: Claude:claude-sonnet-5